### PR TITLE
feat 캐시 데이터 일정 주기로 업로드 기능 생성

### DIFF
--- a/sosik-foodservice/src/main/java/com/example/sosikfoodservice/SosikFoodserviceApplication.java
+++ b/sosik-foodservice/src/main/java/com/example/sosikfoodservice/SosikFoodserviceApplication.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableDiscoveryClient
 @EnableJpaAuditing
+@EnableScheduling
 public class SosikFoodserviceApplication {
 
 	public static void main(String[] args) {

--- a/sosik-foodservice/src/main/java/com/example/sosikfoodservice/config/InitConfig.java
+++ b/sosik-foodservice/src/main/java/com/example/sosikfoodservice/config/InitConfig.java
@@ -6,6 +6,7 @@ import com.example.sosikfoodservice.repository.redis.RedisFood;
 import com.example.sosikfoodservice.repository.redis.RedisFoodRepository;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -23,7 +24,9 @@ public class InitConfig {
 
     private final RedisFoodRepository redisFoodRepository;
     private final FoodRepository foodRepository;
+    private final long executionTime = 1000 * 60 * 28;// 28분마다 한번씩 실행
 
+    @Scheduled(fixedRate = executionTime)
     @PostConstruct
     private void init() {
 


### PR DESCRIPTION
## 🏷 작업 분류

- [X]  기능 추가
- [ ]  리팩토링
- [ ]  버그 수정
- [ ]  환경 수정 및 기타

## 💡 작업 개요
- 현재 캐시 음식 데이터는 30분 후에 삭제됩니다.
- 28분 후로 다시 캐시에 업로드 되도록 작업하였습니다.

## ***📜** 리뷰 요청사항*